### PR TITLE
bcm43xx-utils: add usleep to rdepends

### DIFF
--- a/recipes-connectivity/bcm43xx-utils/bcm43xx-utils.bb
+++ b/recipes-connectivity/bcm43xx-utils/bcm43xx-utils.bb
@@ -13,7 +13,7 @@ FILES:${PN} = " \
 	${sysconfdir}/bluetooth/variscite-bt.d*  \
 "
 
-RDEPENDS:${PN} = "i2c-tools base-files libgpiod-tools var-gpio-utils var-wireless-utils"
+RDEPENDS:${PN} = "i2c-tools base-files libgpiod-tools var-gpio-utils var-wireless-utils usleep"
 
 S = "${WORKDIR}"
 


### PR DESCRIPTION
usleep is used by the wifi init scripts. For example:
- https://github.com/varigit/meta-variscite-bsp-imx/blob/f8125c8fd709605c00ffa9c05d29c0be59c96f27/recipes-connectivity/bcm43xx-utils/bcm43xx-utils/imx8mp-var-dart/bcm43xx-wifi#L69
- https://github.com/varigit-dev/meta-variscite-bsp-ti/blob/26c7491655e7a88e3e74fd3aebf7bd12c9e91166/recipes-connectivity/bcm43xx-utils/bcm43xx-utils/am62x-var-som/bcm43xx-wifi#L67

Add a runtime dependency to make sure usleep is installed.